### PR TITLE
Simplify CI build matrix + build against Go 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
         version:
         - "1.20"
         - "1.21"
+        - "1.22"
     steps:
       - name: Check out source code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,9 @@ jobs:
       fail-fast: false
       # perform matrix testing to give us an earlier insight into issues with different versions of supported major versions of Go
       matrix:
-        # strategy is used to allow us to pin to a specific Go version, or use the version available in our `go.mod`
-        strategy: ['go-version']
-        version: [1.21]
-        include:
-          # pick up the Go version from the `go.mod`
-          - strategy: 'go-version-file'
-            version: 'go.mod'
+        version:
+        - "1.20"
+        - "1.21"
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
@@ -22,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          ${{ matrix.strategy }}: ${{ matrix.version }}
+          go-version: ${{ matrix.version }}
 
       - name: Test
         run: make test

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -11,6 +11,7 @@ jobs:
         version:
         - "1.20"
         - "1.21"
+        - "1.22"
     steps:
       - name: Check out source code
         uses: actions/checkout@v4

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -8,13 +8,9 @@ jobs:
       fail-fast: false
       # perform matrix testing to give us an earlier insight into issues with different versions of supported major versions of Go
       matrix:
-        # strategy is used to allow us to pin to a specific Go version, or use the version available in our `go.mod`
-        strategy: ['go-version']
-        version: [1.21]
-        include:
-          # pick up the Go version from the `go.mod`
-          - strategy: 'go-version-file'
-            version: 'go.mod'
+        version:
+        - "1.20"
+        - "1.21"
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
@@ -22,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          ${{ matrix.strategy }}: ${{ matrix.version }}
+          go-version: ${{ matrix.version }}
 
       - name: Run `make generate`
         run: make generate

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,7 @@ jobs:
         version:
         - "1.20"
         - "1.21"
+        - "1.22"
     steps:
       - name: Check out source code
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,13 +8,9 @@ jobs:
       fail-fast: false
       # perform matrix testing to give us an earlier insight into issues with different versions of supported major versions of Go
       matrix:
-        # strategy is used to allow us to pin to a specific Go version, or use the version available in our `go.mod`
-        strategy: ['go-version']
-        version: [1.21]
-        include:
-          # pick up the Go version from the `go.mod`
-          - strategy: 'go-version-file'
-            version: 'go.mod'
+        version:
+        - "1.20"
+        - "1.21"
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
@@ -22,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          ${{ matrix.strategy }}: ${{ matrix.version }}
+          go-version: ${{ matrix.version }}
 
       - name: Run `make lint-ci`
         run: make lint-ci

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -11,6 +11,7 @@ jobs:
         version:
         - "1.20"
         - "1.21"
+        - "1.22"
     steps:
       - name: Check out source code
         uses: actions/checkout@v4

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -8,13 +8,9 @@ jobs:
       fail-fast: false
       # perform matrix testing to give us an earlier insight into issues with different versions of supported major versions of Go
       matrix:
-        # strategy is used to allow us to pin to a specific Go version, or use the version available in our `go.mod`
-        strategy: ['go-version']
-        version: [1.21]
-        include:
-          # pick up the Go version from the `go.mod`
-          - strategy: 'go-version-file'
-            version: 'go.mod'
+        version:
+        - "1.20"
+        - "1.21"
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
@@ -22,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          ${{ matrix.strategy }}: ${{ matrix.version }}
+          go-version: ${{ matrix.version }}
 
       - name: Install `tidied`
         run: go install gitlab.com/jamietanna/tidied@latest


### PR DESCRIPTION
- chore: simplify CI build matrix
- chore: build against Go 1.22
